### PR TITLE
Remove deprecated packages.

### DIFF
--- a/archlive/packages.x86_64
+++ b/archlive/packages.x86_64
@@ -38,8 +38,6 @@ grub
 hdparm
 hyperv
 intel-ucode
-ipw2100-fw
-ipw2200-fw
 irssi
 iw
 iwd


### PR DESCRIPTION
The firmwares in this commit have been deprecated as per https://lists.archlinux.org/archives/list/arch-dev-public@lists.archlinux.org/thread/UKXPJEJZPU5PFKAPSATNL2DSWFGNEUCK/